### PR TITLE
Compatibility with fabrishot (and possibly other mods)

### DIFF
--- a/common/src/main/java/dev/zelo/renderscale/mixin/MixinWindow.java
+++ b/common/src/main/java/dev/zelo/renderscale/mixin/MixinWindow.java
@@ -1,5 +1,6 @@
 package dev.zelo.renderscale.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.mojang.blaze3d.platform.Window;
 import dev.zelo.renderscale.CommonClass;
 import org.spongepowered.asm.mixin.Mixin;
@@ -7,29 +8,24 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 
 @Mixin(Window.class)
 public abstract class MixinWindow {
-    @Inject(method = "getWidth", at = @At("RETURN"), cancellable = true)
-    private void a(CallbackInfoReturnable<Integer> cir) {
-        var value = renderScale$scale(cir.getReturnValueI());
-        cir.setReturnValue(value);
+    @ModifyReturnValue(method = "getWidth", at = @At("RETURN"))
+    private int renderScale$scaleWidth(int original) {
+        return renderScale$scale(original);
     }
 
-    @Inject(method = "getHeight", at = @At("RETURN"), cancellable = true)
-    private void b(CallbackInfoReturnable<Integer> cir) {
-        var value = renderScale$scale(cir.getReturnValueI());
-        cir.setReturnValue(value);
+    @ModifyReturnValue(method = "getHeight", at = @At("RETURN"))
+    private int renderScale$scaleHeight(int original) {
+        return renderScale$scale(original);
     }
 
-    @Inject(method = "getGuiScale", at = @At("RETURN"), cancellable = true)
-    private void c(CallbackInfoReturnable<Integer> cir) {
+    @ModifyReturnValue(method = "getGuiScale", at = @At("RETURN"))
+    private int renderScale$modifyGuiScale(int original) {
         // It's NeoForges' fault for this null check
-        if (CommonClass.getInstance() != null) {
-            cir.setReturnValue((int) (cir.getReturnValueI() * (CommonClass.getInstance().getCurrentScaleFactor())));
-        }
+        return CommonClass.getInstance() == null ? original : (int) (original * CommonClass.getInstance().getCurrentScaleFactor());
     }
 
     @Inject(method = "onFramebufferResize", at = @At("RETURN"))


### PR DESCRIPTION
Fixes #70 

Makes use of the @ModifyReturnValue injector from MixinExtras to change window size. This way the target method won't be immediately cancelled and other mods may modify the window size further.
