### PR TITLE
fix: 1.20.1 Forge Incompatibility with epic fight nightfall

### DIFF
--- a/src/main/resources/renderscale.mixins.json
+++ b/src/main/resources/renderscale.mixins.json
@@ -7,6 +7,8 @@
   "injectors": {
     "defaultRequire": 1
   },
-  "client": [],
+  "client": [
+    "MixinGameRenderer"
+  ],
   "mixins": []
 }


### PR DESCRIPTION
Closes #83

Patch generated by `openrouter/free` via OpenRouter.